### PR TITLE
Bump pyromod from 1.5 to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dnspython==2.2.1
 motor==3.1.1
 psutil==5.9.4
-pyromod==1.5
+pyromod==2.0.0
 pyrogram==2.0.88
 pyrogram1==0.1.0
 python-dotenv==0.21.0


### PR DESCRIPTION
Bumps [pyromod]() from 1.5 to 2.0.0.

---
updated-dependencies:
- dependency-name: pyromod dependency-type: direct:production update-type: version-update:semver-major ...